### PR TITLE
Correct link to Serializer page

### DIFF
--- a/docs/general/getting_started.md
+++ b/docs/general/getting_started.md
@@ -47,7 +47,7 @@ The `has_many`, `has_one`, and `belongs_to` declarations describe relationships 
 resources. By default, when you serialize a `Post`, you will get its `Comments`
 as well.
 
-For more information, see [Serializers](docs/general/serializers.md).
+For more information, see [Serializers](https://github.com/rails-api/active_model_serializers/blob/master/docs/general/serializers.md).
 
 ### Namespaced Models
 


### PR DESCRIPTION
Fixed the broken link  to the Serializers page on the Getting Started page. 
